### PR TITLE
Display homepage image & journal summary

### DIFF
--- a/ClassicThemePlugin.inc.php
+++ b/ClassicThemePlugin.inc.php
@@ -37,7 +37,6 @@ class ClassicThemePlugin extends ThemePlugin
 		// Option to show journal summary
 		$this->addOption('journalSummary', 'radio', array(
 			'label' => 'manager.setup.journalSummary',
-			'description' => 'plugins.themes.classic.options.journalSummary.description',
 			'options' => array(
 				0 => 'plugins.themes.classic.options.journalSummary.disable',
 				1 => 'plugins.themes.classic.options.journalSummary.enable'

--- a/ClassicThemePlugin.inc.php
+++ b/ClassicThemePlugin.inc.php
@@ -29,11 +29,20 @@ class ClassicThemePlugin extends ThemePlugin
 			'default' => '#ffd120',
 		));
 
-
 		$additionalLessVariables = [];
 		if ($this->getOption('primaryColor') !== '#ffd120') {
 			$additionalLessVariables[] = '@primary-colour:' . $this->getOption('primaryColor') . ';';
 		}
+
+		// Option to show journal summary
+		$this->addOption('journalSummary', 'radio', array(
+			'label' => 'manager.setup.journalSummary',
+			'description' => 'plugins.themes.classic.options.journalSummary.description',
+			'options' => array(
+				0 => 'plugins.themes.classic.options.journalSummary.disable',
+				1 => 'plugins.themes.classic.options.journalSummary.enable'
+			)
+		));
 
 		// Importing Bootstrap's and tag-it CSS
 		$this->addStyle('app_css', 'resources/app.min.css');
@@ -78,6 +87,8 @@ class ClassicThemePlugin extends ThemePlugin
 		HookRegistry::register('TemplateManager::display', array($this, 'loadIssueData'));
 		// Check whether authors have additional info
 		HookRegistry::register('TemplateManager::display', array($this, 'hasAuthorsInfo'));
+		// Display journal summary on the homepage
+		HookRegistry::register ('TemplateManager::display', array($this, 'homepageJournalSummary'));
 	}
 
 	public function getDisplayName() {
@@ -207,6 +218,17 @@ class ClassicThemePlugin extends ThemePlugin
 		}
 
 		$templateMgr->assign('boolAuthorInfo', $boolAuthorInfo);
+	}
+
+	public function homepageJournalSummary($hookName, $args) {
+		$templateMgr = $args[0];
+		$template = $args[1];
+
+		if ($template != "frontend/pages/indexJournal.tpl") return false;
+
+		$templateMgr->assign(array(
+			'showJournalSummary' => $this->getOption('journalSummary'),
+		));
 	}
 
 }

--- a/less/common/formErrors.less
+++ b/less/common/formErrors.less
@@ -16,7 +16,7 @@
 	border: 1px solid #721c24;;
 
 	& a {
-		color: @black-two;
+		color: @dark-grey;
 	}
 }
 

--- a/less/common/formErrors.less
+++ b/less/common/formErrors.less
@@ -16,7 +16,7 @@
 	border: 1px solid #721c24;;
 
 	& a {
-		color: @gunmetal;
+		color: @black-two;
 	}
 }
 

--- a/less/components/footer.less
+++ b/less/components/footer.less
@@ -29,7 +29,7 @@ footer a {
 	color: inherit;
 
 	&:hover {
-		color: @white;
+		color: #FFF;
 	}
 }
 
@@ -87,7 +87,7 @@ footer a {
 	width: auto;
 	border-radius: 0;
 	padding: 0;
-	border:0;
+	border: 0;
 }
 
 .block_web_feed ul {
@@ -101,8 +101,8 @@ footer a {
 
 .block_make_submission_link {
 	.button();
-	border: 1px solid @black;
-	background-color: @black;
+	border: 1px solid #000;
+	background-color: #000;
 	color: white;
 	display: inline-block;
 	text-align: center;
@@ -114,7 +114,7 @@ footer a {
 		text-decoration: none;
 		background-color: #FFF;
 		border: 1px solid #FFF;
-		color: #000
+		color: #000;
 	}
 }
 
@@ -153,14 +153,14 @@ footer a {
 	}
 	.pkpbrand-wrapper {
 		max-width: 100%;
-		flex: 0 0 100%
+		flex: 0 0 100%;
 	}
 }
 
 .sidebar_wrapper + .additional-footer-info {
 	margin-top: 40px;
 	padding-top: 35px;
-	border-top: 1px solid @black;
+	border-top: 1px solid #000;
 }
 
 .footer-brand-image {

--- a/less/components/footer.less
+++ b/less/components/footer.less
@@ -112,8 +112,9 @@ footer a {
 
 	&:hover {
 		text-decoration: none;
-		background-color: @gunmetal;
-		border: 1px solid @gunmetal;
+		background-color: #FFF;
+		border: 1px solid #FFF;
+		color: #000
 	}
 }
 

--- a/less/components/header.less
+++ b/less/components/header.less
@@ -24,6 +24,12 @@
 	min-height: @minHeight-userMenu;
 }
 
+.homepage-image {
+	display: block;
+	min-height: 35vh;
+	background-size: cover;
+	background-position: center;
+}
 
 .user-dropdown a:focus {
 	background-color: @primary-colour;

--- a/less/components/header.less
+++ b/less/components/header.less
@@ -12,7 +12,7 @@
 // all header
 
 .header {
-	background-color: @black;
+	background-color: #000;
 	padding-top: 7px;
 }
 
@@ -96,7 +96,7 @@
 
 .task_count {
 	background-color: white;
-	color: @black;
+	color: #000;
 	font-weight: bolder;
 	display: inline-block;
 	border-radius: 10px;
@@ -115,7 +115,7 @@
 
 .navigation-dropdown.show .task_count {
 	display: inline-block;
-	background-color: @black;
+	background-color: #000;
 	padding-left: 7px;
 	padding-right: 7px;
 	border-radius: 10px;
@@ -126,7 +126,7 @@
 
 // menu dropdown
 .nav-item.show .nav-link.dropdown-toggle {
-	background-color: @black;
+	background-color: #000;
 	color: @primary-colour;
 }
 
@@ -136,7 +136,7 @@
 
 	&:focus, &:hover, &:active {
 		background-color: @primary-colour;
-		color: @black;
+		color: #000;
 	}
 
 }
@@ -156,7 +156,7 @@
 }
 
 .journal-logo-text {
-	color: @white;
+	color: #FFF;
 	padding-top: 5px;
 	font-family: @font-family-primary;
 	font-size: 22px;
@@ -183,7 +183,7 @@
 @media (max-width: 991px) {
 	#navigationUser, #languageNav {
 		& .nav-item.show .nav-link.dropdown-toggle {
-			background-color: @black;
+			background-color: #000;
 		}
 	}
 
@@ -231,7 +231,7 @@
 @media (max-width: 991px) {
 	#show-modal {
 		cursor: pointer;
-		color: @white;
+		color: #FFF;
 		&:focus, &:hover {
 			color: @primary-colour;
 		}

--- a/less/components/header.less
+++ b/less/components/header.less
@@ -24,13 +24,6 @@
 	min-height: @minHeight-userMenu;
 }
 
-.homepage-image {
-	display: block;
-	min-height: 35vh;
-	background-size: cover;
-	background-position: center;
-}
-
 .user-dropdown a:focus {
 	background-color: @primary-colour;
 }

--- a/less/components/notification.less
+++ b/less/components/notification.less
@@ -10,7 +10,7 @@
  */
 
 .cmp_notification {
-	background-color: @pinkish-grey;
+	background-color: @light-grey;
 	color: white;
 	padding: 7px;
 	border-radius: 5px;
@@ -18,7 +18,7 @@
 	margin-bottom: 15px;
 
 	& a {
-		color: @black;
+		color: #000;
 	}
 
 	&.notice {

--- a/less/components/notification.less
+++ b/less/components/notification.less
@@ -18,7 +18,7 @@
 	margin-bottom: 15px;
 
 	& a {
-		color: @gunmetal;
+		color: @black;
 	}
 
 	&.notice {

--- a/less/components/pagination.less
+++ b/less/components/pagination.less
@@ -15,12 +15,12 @@
 }
 
 .page-item .page-link {
-	color: @black;
+	color: #000;
 
 	&:hover {
 		color: #fff;
-		background-color: @black;
-		border: 1px solid @black;
+		background-color: #000;
+		border: 1px solid #000;
 	}
 }
 
@@ -34,7 +34,7 @@
 	background-color: @primary-colour;
 	border-color: @primary-colour;
 	box-shadow: none;
-	color: @black;
+	color: #000;
 	pointer-events: none;
 }
 

--- a/less/components/registrationForm.less
+++ b/less/components/registrationForm.less
@@ -52,7 +52,7 @@
 }
 
 .text-icon {
-	color: @gunmetal;
+	color: @primary-colour;
 }
 
 ul.tagit li.tagit-choice .tagit-close .text-icon {

--- a/less/forms.less
+++ b/less/forms.less
@@ -87,16 +87,16 @@ select {
 	box-shadow: none;
 
 	&:hover {
-		background-color: @black;
+		background-color: #000;
 		text-decoration: none;
 		color: white;
 		box-shadow: none;
 	}
 
 	&:focus {
-		background-color: @black;
+		background-color: #000;
 		color: white;
-		border-color: @black;
+		border-color: #000;
 	}
 
 }
@@ -121,13 +121,13 @@ select {
 		background-color: @primary-colour;
 		border-color: @primary-colour;
 		text-decoration: none;
-		color: @white;
+		color: #FFF;
 
 	}
 }
 
 .btn-primary:not(:disabled):not(.disabled):active, .btn-primary:not(:disabled):not(.disabled).active {
-	background-color: @black;
+	background-color: #000;
 }
 
 // OJS classes
@@ -139,14 +139,14 @@ select {
 }
 
 .more_button {
-	color: @black;
+	color: #000;
 	border-bottom: 3px solid @primary-colour;
 	line-height: 10px;
 	display: inline-block;
 	cursor: pointer;
 
 	&:hover {
-		color: @black;
+		color: #000;
 		text-decoration: none;
 	}
 }

--- a/less/forms.less
+++ b/less/forms.less
@@ -118,7 +118,8 @@ select {
 	font-size: 18px;
 
 	&:hover {
-		background-color: @gunmetal;
+		background-color: @primary-colour;
+		border-color: @primary-colour;
 		text-decoration: none;
 		color: @white;
 

--- a/less/objects/announcement_summary.less
+++ b/less/objects/announcement_summary.less
@@ -25,7 +25,7 @@
 
 .announcement-summary-heading {
 	font-family: @font-family-primary;
-	color: @black;
+	color: #000;
 	font-size: 20px;
 	line-height: 1.2;
 

--- a/less/objects/announcements_full.less
+++ b/less/objects/announcements_full.less
@@ -10,7 +10,7 @@
  */
 
 .announcement-full-date {
-	color: @warm-grey;
+	color: @mid-grey;
 	margin-top: 30px;
 	margin-bottom: 20px;
 }

--- a/less/objects/article_details.less
+++ b/less/objects/article_details.less
@@ -15,7 +15,7 @@
 	font-family: @font-family-primary;
 	font-size: 20px;
 	font-weight: bold;
-	color: @gunmetal;
+	color: @black-two;
 	padding-top: 9px;
 	padding-bottom: 17px;
 }

--- a/less/objects/article_details.less
+++ b/less/objects/article_details.less
@@ -15,13 +15,13 @@
 	font-family: @font-family-primary;
 	font-size: 20px;
 	font-weight: bold;
-	color: @black-two;
+	color: @dark-grey;
 	padding-top: 9px;
 	padding-bottom: 17px;
 }
 
 .article_section_title {
-	color: @warm-grey;
+	color: @mid-grey;
 	font-size: 14px;
 	font-family: @font-family-primary;
 	text-transform: uppercase;
@@ -61,7 +61,7 @@
 }
 
 .name_wrapper {
-	color: @black;
+	color: #000;
 }
 
 @media (max-width: 767px) {
@@ -94,7 +94,7 @@
 
 	.collapse-authors {
 		font-family: "Cardo", serif;
-		color: @black-two;
+		color: @dark-grey;
 		line-height: 1.5;
 	}
 
@@ -114,12 +114,12 @@
 }
 
 .more-authors-info-button {
-	color: @black;
+	color: #000;
 	text-transform: capitalize;
 
 	&:hover {
 		text-decoration: none;
-		color: @black-two;
+		color: @dark-grey;
 	}
 }
 
@@ -168,12 +168,12 @@
 // doi and date
 
 .doi, .published_date {
-	color: @warm-grey;
+	color: @mid-grey;
 	font-size: 14px;
 }
 
 .doi_value a {
-	color: @warm-grey;
+	color: @mid-grey;
 
 	&:hover {
 		color: @primary-colour;
@@ -196,7 +196,7 @@
 
 .affiliation_wrapper, .author_orcid {
 	font-size: 14px;
-	color: @warm-grey;
+	color: @mid-grey;
 }
 
 // keywords
@@ -312,7 +312,7 @@
 }
 
 .abstract_label {
-	color: @black;
+	color: #000;
 	padding-bottom: 3px;
 }
 
@@ -369,7 +369,7 @@
 
 		& h3 {
 			font-size: 30px;
-			color: @black-two;
+			color: @dark-grey;
 		}
 
 		& .doi {

--- a/less/objects/article_summary.less
+++ b/less/objects/article_summary.less
@@ -16,7 +16,7 @@
 
 .summary_title {
 	font-family: @font-family-primary;
-	color: @black;
+	color: #000;
 	font-size: 20px;
 	font-weight: normal;
 	line-height: 1.2;
@@ -31,7 +31,7 @@
 	font-family: @font-family-secondary;
 	line-height: 1.25;
 	font-size: small;
-	color: @warm-grey;
+	color: @mid-grey;
 }
 
 .summary_meta div:not(:last-child) {

--- a/less/objects/issue_summary.less
+++ b/less/objects/issue_summary.less
@@ -27,7 +27,7 @@ span + .current-issue-year:after {
 
 .issue_title {
 	font-family: "Cardo", serif;
-	color: @black;
+	color: #000;
 	line-height: 1.5;
 	font-size: 17px;
 	border-bottom: none;
@@ -45,19 +45,19 @@ span + .current-issue-year:after {
 }
 
 .issue_summary_title {
-	color: @black;
+	color: #000;
 	font-size: 18px;
 	font-family: @font-family-primary;
 	line-height: 1.5;
 
 	&:hover {
 		text-decoration: underline;
-		color: @black;
+		color: #000;
 	}
 }
 
 .issue_summary_date {
-	color: @warm-grey;
+	color: @mid-grey;
 	font-size: small;
 	font-family: @font-family-secondary;
 	padding: 0;
@@ -65,6 +65,6 @@ span + .current-issue-year:after {
 }
 
 .issue_summary_description_text {
-	color: @warm-grey;
+	color: @mid-grey;
 	font-size: 14px;
 }

--- a/less/objects/issue_toc.less
+++ b/less/objects/issue_toc.less
@@ -79,10 +79,10 @@
 }
 
 .section_title {
-	font-family: @font-family-primary;
-	font-size: 18px;
-	color: @gunmetal;
-	font-weight: bold;
+	font-family: @font-family-secondary;
+	font-size: 16px;
+	color: @black-two;
+	font-weight: normal;
 	padding-bottom: 42px;
 	padding-top: 3px;
 }

--- a/less/objects/issue_toc.less
+++ b/less/objects/issue_toc.less
@@ -12,7 +12,7 @@
 // date published
 
 .published {
-	color: @warm-grey;
+	color: @mid-grey;
 	font-size: small;
 	font-family: @font-family-secondary;
 }
@@ -81,7 +81,7 @@
 .section_title {
 	font-family: @font-family-secondary;
 	font-size: 16px;
-	color: @black-two;
+	color: @dark-grey;
 	font-weight: normal;
 	padding-bottom: 42px;
 	padding-top: 3px;

--- a/less/page.less
+++ b/less/page.less
@@ -47,7 +47,7 @@
 	border-bottom: 3px solid @primary-colour;
 	font-size: 18px;
 	font-family: @font-family-primary;
-	color: @black;
+	color: #000;
 	margin-bottom: 20px;
 
 	&:hover {
@@ -92,7 +92,7 @@
 	& a, strong {
 		border: 1px solid #ced4da;
 		padding: 5px;
-		color: @black-two;
+		color: @dark-grey;
 	}
 
 	& strong {
@@ -144,7 +144,7 @@
 }
 
 .modal-header {
-	background-color: @black-two;
+	background-color: @dark-grey;
 	color: white;
 
 	& .close span {

--- a/less/pages/htmlGalley.less
+++ b/less/pages/htmlGalley.less
@@ -28,7 +28,7 @@
 }
 
 .header_view {
-	background-color: @black-two;
+	background-color: @dark-grey;
 	position: relative;
 	z-index: 2;
 }
@@ -46,7 +46,7 @@
 	&:before {
 		content: "\21b5";
 		display: inline-block;
-		color: @black-two;
+		color: @dark-grey;
 	}
 }
 

--- a/less/pages/indexJournal.less
+++ b/less/pages/indexJournal.less
@@ -9,14 +9,13 @@
  *
  */
 
-
 .homepage_image {
 	min-height: 35vh;
 	background-size: cover;
 	background-position: center;
 	display: flex;
-  align-items: center;
-  justify-content: center;
+	align-items: center;
+	justify-content: center;
 }
 
 .journal_summary {
@@ -26,7 +25,7 @@
 
 .current_issue header {
 	margin-bottom: 100px;
- }
+}
 
 .current_issue_title span {
 	display: block;
@@ -35,7 +34,7 @@
 .current_issue_label {
 	font-family: @font-family-secondary;
 	font-weight: 400;
-  font-size: 16px;
+	font-size: 16px;
 }
 
 .current_issue_identification {

--- a/less/pages/indexJournal.less
+++ b/less/pages/indexJournal.less
@@ -9,8 +9,23 @@
  *
  */
 
+
+.homepage_image {
+	min-height: 35vh;
+	background-size: cover;
+	background-position: center;
+	display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.journal_summary {
+	margin-top: 3em;
+	margin-bottom: 3em;
+}
+
 .current_issue header {
-	 margin-bottom: 100px;
+	margin-bottom: 100px;
  }
 
 .current_issue_title span {

--- a/less/pages/indexSite.less
+++ b/less/pages/indexSite.less
@@ -24,7 +24,7 @@
 
 	& h2 {
 		margin-bottom: 30px;
-		color: @black;
+		color: #000;
 		font-family: "Cardo", serif;
 		font-size: 40px;
 	}
@@ -32,7 +32,7 @@
 	& h3 {
 		margin-top: 20px;
 		margin-bottom: 20px;
-		color: @black-two;
+		color: @dark-grey;
 		font-size: 32px;
 		font-family: "Cardo", serif;
 	}

--- a/less/pages/orcidProfile.less
+++ b/less/pages/orcidProfile.less
@@ -30,7 +30,7 @@
 	border-style: solid;
 	font-size: 14px;
 	background-color: #fff;
-	border-color: @black;
+	border-color: #000;
 	font-weight: 600;
 	color: #000;
 	.button();
@@ -38,14 +38,14 @@
 	&:hover {
 		background-color: @primary-colour;
 		text-decoration: none;
-		color: @black;
+		color: #000;
 		box-shadow: none;
 	}
 
 	&:focus {
 		background-color: @primary-colour;
-		color: @black;
-		border-color: @black;
+		color: #000;
+		border-color: #000;
 	}
 
 	&:hover, &:not(:disabled):not(.disabled).active {

--- a/less/pages/pdfGalley.less
+++ b/less/pages/pdfGalley.less
@@ -26,12 +26,12 @@
 
 	& a {
 		font-family: @font-family-primary;
-		color: @black;
+		color: #000;
 		font-size: 18px;
 
 		&:hover {
 			text-decoration: none;
-			border-bottom: 1px dotted @black;
+			border-bottom: 1px dotted #000;
 		}
 	}
 }

--- a/less/pages/searchAuthorDetails.less
+++ b/less/pages/searchAuthorDetails.less
@@ -29,7 +29,7 @@
 .author-details-issue a {
 	border-bottom: none;
 	box-shadow: none;
-	color: @gunmetal;
+	color: @black-two;
 	font-weight: bold;
 	font-size: 16px;
 
@@ -39,7 +39,7 @@
 }
 
 .author-details-section {
-	color: @gunmetal;
+	color: @black-two;
 	font-weight: bold;
 	font-size: 16px;
 }

--- a/less/pages/searchAuthorDetails.less
+++ b/less/pages/searchAuthorDetails.less
@@ -29,7 +29,7 @@
 .author-details-issue a {
 	border-bottom: none;
 	box-shadow: none;
-	color: @black-two;
+	color: @dark-grey;
 	font-weight: bold;
 	font-size: 16px;
 
@@ -39,13 +39,13 @@
 }
 
 .author-details-section {
-	color: @black-two;
+	color: @dark-grey;
 	font-weight: bold;
 	font-size: 16px;
 }
 
 .author-details-article a {
-	color: @black;
+	color: #000;
 	font-size: 20px;
 	border-bottom: 0;
 	box-shadow: none;

--- a/less/pages/searchAuthorIndex.less
+++ b/less/pages/searchAuthorIndex.less
@@ -19,7 +19,7 @@
 	flex-wrap: wrap;
 
 	& strong, a {
-		border: 1px solid @pinkish-grey;
+		border: 1px solid @light-grey;
 		padding-left: 5px;
 		padding-right: 5px;
 	}
@@ -30,7 +30,7 @@
 	}
 
 	& a {
-		border-bottom-color: @pinkish-grey;
+		border-bottom-color: @light-grey;
 		box-shadow: none;
 
 		&:hover {

--- a/less/pages/userRegisterComplete.less
+++ b/less/pages/userRegisterComplete.less
@@ -23,7 +23,7 @@
 
 	& a {
 		padding-left: 5px;
-		color: @black;
+		color: #000;
 	}
 
 	& a:hover {

--- a/less/plugins/recommendByAuthor/articleFooter.less
+++ b/less/plugins/recommendByAuthor/articleFooter.less
@@ -24,17 +24,17 @@
 		border-color: transparent;
 		border-style: solid;
 		border-width: 5px;
-		border-top-color: @black;
+		border-top-color: #000;
 		transform: rotate(-90deg);
 	}
 
 	& li a {
 		margin-right: -4px;
-		color: @black;
+		color: #000;
 
 		&:hover {
 			text-decoration: none;
-			border-bottom: 1px dotted @black;
+			border-bottom: 1px dotted #000;
 		}
 	}
 
@@ -62,7 +62,7 @@
 	}
 
 	& a {
-		color: @black-two;
+		color: @dark-grey;
 	}
 
 	& strong {

--- a/less/typography.less
+++ b/less/typography.less
@@ -143,7 +143,7 @@ p {
 }
 
 .nav-link {
-	color: @white;
+	color: #FFF;
 	font-family: @font-family-secondary;
 	font-size: 14px;
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -15,12 +15,10 @@
 
 /* site-wide color variables */
 
-@primary-colour: #ffd120;
-@black: #000000;
-@warm-grey: #757575;
-@black-two: #333333;
-@white: #ffffff;
-@pinkish-grey: #cccccc;
+@primary-colour: #FFD120;
+@light-grey: #CCC;
+@mid-grey: #757575;
+@dark-grey: #333333;
 
 /* header variables */
 @minHeight-userMenu: 100px;

--- a/less/variables.less
+++ b/less/variables.less
@@ -18,7 +18,6 @@
 @primary-colour: #ffd120;
 @black: #000000;
 @warm-grey: #757575;
-@gunmetal: #4d6066;
 @black-two: #333333;
 @white: #ffffff;
 @pinkish-grey: #cccccc;

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -24,8 +24,7 @@
 	<message key="plugins.themes.classic.register.privacyConsent">Yes, I agree to have my data collected and stored according to the journal's Policy Statement:</message>
 	<message key="plugins.themes.classic.register.privacyConsentContext"><![CDATA[The <a href="{$privacyUrl}" target="_blank">Policy Statement</a> of {$privacyContextName}.]]></message>
 
-	<message key="plugins.themes.classic.options.journalSummary.description">If enabled, the journal summary will be shown on the journal’s landing page.</message>
-	<message key="plugins.themes.classic.options.journalSummary.disable">Disable (default)</message>
-	<message key="plugins.themes.classic.options.journalSummary.enable">Enable</message>
+	<message key="plugins.themes.classic.options.journalSummary.disable"> Do not show on the journal's homepage.</message>
+	<message key="plugins.themes.classic.options.journalSummary.enable">Show on the journal's homepage.</message>
 
 </locale>

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -24,4 +24,8 @@
 	<message key="plugins.themes.classic.register.privacyConsent">Yes, I agree to have my data collected and stored according to the journal's Policy Statement:</message>
 	<message key="plugins.themes.classic.register.privacyConsentContext"><![CDATA[The <a href="{$privacyUrl}" target="_blank">Policy Statement</a> of {$privacyContextName}.]]></message>
 
+	<message key="plugins.themes.classic.options.journalSummary.description">If enabled, the journal summary will be shown on the journal’s landing page.</message>
+	<message key="plugins.themes.classic.options.journalSummary.disable">Disable (default)</message>
+	<message key="plugins.themes.classic.options.journalSummary.enable">Enable</message>
+
 </locale>

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -21,6 +21,11 @@
 {include file="frontend/components/header.tpl" pageTitleTranslated=$currentJournal->getLocalizedName()}
 
 <main class="page_index_journal">
+	{* Display homepage image if set *}
+	{if $homepageImage}
+		<div class="homepage-image" style="background-image: url('{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}')"></div>
+	{/if}
+
 	<div class="container-fluid container-page">
 
 		{* Announcements *}

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -29,7 +29,7 @@
 			style="background: {if $showJournalSummary}linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)), {/if}url('{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}')">
 	{/if}
 
-	{if $showJournalSummary}
+	{if $showJournalSummary && $currentJournal->getLocalizedDescription()}
 		<section class="container journal_summary"{if $homepageImage}style="color: #FFF"{/if}>
 			<h2>{translate key="navigation.about"}</h2>
 			{$currentJournal->getLocalizedDescription()}

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -24,11 +24,13 @@
 
 	{* Display homepage image if set, and wrap around journal summary if use chooses to display it *}
 	{if $homepageImage}
-		<div class="homepage_image" style="background-image: url('{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}')">
+		<div
+			class="homepage_image"
+			style="background: {if $showJournalSummary}linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)), {/if}url('{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}')">
 	{/if}
 
 	{if $showJournalSummary}
-		<section class="container journal_summary">
+		<section class="container journal_summary"{if $homepageImage}style="color: #FFF"{/if}>
 			<h2>{translate key="navigation.about"}</h2>
 			{$currentJournal->getLocalizedDescription()}
 		</section>

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -21,9 +21,21 @@
 {include file="frontend/components/header.tpl" pageTitleTranslated=$currentJournal->getLocalizedName()}
 
 <main class="page_index_journal">
-	{* Display homepage image if set *}
+
+	{* Display homepage image if set, and wrap around journal summary if use chooses to display it *}
 	{if $homepageImage}
-		<div class="homepage-image" style="background-image: url('{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}')"></div>
+		<div class="homepage_image" style="background-image: url('{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}')">
+	{/if}
+
+	{if $showJournalSummary}
+		<section class="container journal_summary">
+			<h2>{translate key="navigation.about"}</h2>
+			{$currentJournal->getLocalizedDescription()}
+		</section>
+	{/if}
+
+	{if $homepageImage}
+		</div>
 	{/if}
 
 	<div class="container-fluid container-page">


### PR DESCRIPTION
Close #32, #28 

Suggesting in this PR to display both the homepage image and homepage journal summary in the same block. These changes can anticipate the four following cases: 

1. User only selects the homepage image to be displayed → it is displayed as a background image, taking up a minimum of 25% of the height of the user’s viewport.  
<img width="1440" alt="Screen Shot 2019-08-07 at 13 13 06" src="https://user-images.githubusercontent.com/6668406/62622079-65824a00-b915-11e9-8de3-792916ec4425.png">


2. User only selects the journal summary to be displayed → it is displayed, in black text, with some margins around it to make it stand out from the header and the rest of the page.  
<img width="1440" alt="Screen Shot 2019-08-07 at 13 13 42" src="https://user-images.githubusercontent.com/6668406/62622056-54d1d400-b915-11e9-83fb-53df01e34f3b.png">

3. User selects both options to be enabled → we darken the background image and display the journal summary’s text in white, to make it stand out.  
<img width="1439" alt="Screen Shot 2019-08-07 at 13 12 51" src="https://user-images.githubusercontent.com/6668406/62622100-78951a00-b915-11e9-9919-207b3318efef.png">

4. User selects both options to be disabled → nothing is displayed.  
<img width="1438" alt="Screen Shot 2019-08-07 at 13 16 08" src="https://user-images.githubusercontent.com/6668406/62622130-8a76bd00-b915-11e9-8388-fd972aa3be86.png">

