### PR TITLE
pkp/pkp-lib#4870 Update theme for 3.2

### DIFF
--- a/ClassicThemePlugin.inc.php
+++ b/ClassicThemePlugin.inc.php
@@ -29,6 +29,15 @@ class ClassicThemePlugin extends ThemePlugin
 			'default' => '#ffd120',
 		));
 
+		// Option to show journal summary
+		$this->addOption('journalSummary', 'radio', array(
+			'label' => 'manager.setup.journalSummary',
+			'options' => array(
+				0 => 'plugins.themes.classic.options.journalSummary.disable',
+				1 => 'plugins.themes.classic.options.journalSummary.enable'
+			)
+		));
+
 		// Calculate secondary colour based on user’s primary colour choice
 		$additionalLessVariables = [];
 		if ($this->getOption('primaryColor') !== '#ffd120') {
@@ -45,15 +54,6 @@ class ClassicThemePlugin extends ThemePlugin
 				@secondary-colour: lighten(@primary-colour, 45%);
 			';
 		}
-
-		// Option to show journal summary
-		$this->addOption('journalSummary', 'radio', array(
-			'label' => 'manager.setup.journalSummary',
-			'options' => array(
-				0 => 'plugins.themes.classic.options.journalSummary.disable',
-				1 => 'plugins.themes.classic.options.journalSummary.enable'
-			)
-		));
 
 		// Importing Bootstrap's and tag-it CSS
 		$this->addStyle('app_css', 'resources/app.min.css');
@@ -235,7 +235,7 @@ class ClassicThemePlugin extends ThemePlugin
 		$templateMgr = $args[0];
 		$template = $args[1];
 
-		if ($template != "frontend/pages/indexJournal.tpl") return false;
+		if ($template !== "frontend/pages/indexJournal.tpl") return false;
 
 		$templateMgr->assign(array(
 			'showJournalSummary' => $this->getOption('journalSummary'),

--- a/less/pages/htmlGalley.less
+++ b/less/pages/htmlGalley.less
@@ -63,6 +63,15 @@
 	white-space: nowrap;
 }
 
+.header_view .cmp_notification {
+	padding: 0;
+	color: #fff;
+
+	a {
+		color: #fff;
+	}
+}
+
 .pkp_screen_reader {
 	position: absolute !important;
 	left: -5000px;

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -192,17 +192,37 @@
 				{/if}
 			{/foreach}
 
-			{* Published date *}
-			{if $article->getDatePublished()}
-				<div class="published_date">
-					<span class="published_date_label">
-						{translate key="submissions.published"}
-					</span>
-					<span class="published_date_value">
-						{$article->getDatePublished()|date_format:$dateFormatLong}
-					</span>
-				</div>
-			{/if}
+			{* Publication & update dates; previous versions *}
+      {if $publication->getData('datePublished')}
+        <p>
+          {translate key="submissions.published"}
+          {* If this is the original version *}
+          {if $firstPublication->getID() === $publication->getId()}
+            {$firstPublication->getData('datePublished')|date_format:$dateFormatShort}
+          {* If this is an updated version *}
+          {else}
+            {translate key="submission.updatedOn" datePublished=$firstPublication->getData('datePublished')|date_format:$dateFormatShort dateUpdated=$publication->getData('datePublished')|date_format:$dateFormatShort}
+          {/if}
+        </p>
+
+        {if count($article->getPublishedPublications()) > 1}
+          <h3>{translate key="submission.versions"}</h3>
+          <ul>
+            {foreach from=array_reverse($article->getPublishedPublications()) item=iPublication}
+              {capture assign="name"}{translate key="submission.versionIdentity" datePublished=$iPublication->getData('datePublished')|date_format:$dateFormatShort version=$iPublication->getData('version')}{/capture}
+              <li>
+                {if $iPublication->getId() === $publication->getId()}
+                  {$name}
+                {elseif $iPublication->getId() === $currentPublication->getId()}
+                  <a href="{url page="article" op="view" path=$article->getBestId()}">{$name}</a>
+                {else}
+                  <a href="{url page="article" op="view" path=$article->getBestId()|to_array:"version":$iPublication->getId()}">{$name}</a>
+                {/if}
+              </li>
+            {/foreach}
+          </ul>
+        {/if}
+      {/if}
 
 			{* Keywords *}
 			{if !empty($keywords[$currentLocale])}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -383,20 +383,20 @@
 			{call_hook name="Templates::Article::Main"}
 
 			{* References *}
-			{if $parsedCitations->getCount() || $article->getCitations()}
+			{if $parsedCitations || $publication->getData('citationsRaw')}
 				<div class="item references">
 					<h3 class="label">
 						{translate key="submission.citations"}
 					</h3>
-					{if $parsedCitations->getCount()}
+					{if $parsedCitations}
 						<ol class="references-list">
-							{iterate from=parsedCitations item=parsedCitation}
+							{foreach from=$parsedCitations item=parsedCitation}
 								<li>{$parsedCitation->getCitationWithLinks()|strip_unsafe_html} {call_hook name="Templates::Article::Details::Reference" citation=$parsedCitation}</li>
-							{/iterate}
+							{/foreach}
 						</ol>
-					{elseif $article->getCitations()}
+					{else}
 						<div class="value">
-							{$article->getCitations()|nl2br}
+							{$publication->getData('citationsRaw')|nl2br}
 						</div>
 					{/if}
 				</div>

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -48,7 +48,7 @@
 
 				{* article title, subtitle and authors *}
 				<h1 class="page_title article-full-title">
-					{$article->getLocalizedFullTitle()|escape}
+					{$publication->getLocalizedFullTitle()|escape}
 				</h1>
 
 
@@ -77,11 +77,11 @@
 			<div class="col-md-12">
 
 				{* authors list *}
-				{if $article->getAuthors()}
+				{if $publication->getData('authors')}
 					<div class="authors_info">
 						<ul class="entry_authors_list">
 							{strip}
-								{foreach from=$article->getAuthors() item=author key=authorNumber}
+								{foreach from=$publication->getData('authors') item=author key=authorNumber}
 									<li class="entry_author_block{if $authorNumber > 4} limit-for-mobiles{elseif $authorNumber === 4} fifth-author{/if}">
 										{if $author->getOrcid()}
 											<a class="orcid-image-url" href="{$author->getOrcid()}"><img src="{$baseUrl}/{$orcidImageUrl}"></a>
@@ -89,12 +89,12 @@
 										<span class="name_wrapper">
 											{$author->getFullName()|escape}
 										</span>
-										{if $authorNumber+1 !== $article->getAuthors()|@count}
+										{if $authorNumber+1 !== $publication->getData('authors')|@count}
 											<span class="author-delimiter">, </span>
 										{/if}
 									</li>
 								{/foreach}
-								{if $article->getAuthors()|@count > 4}
+								{if $publication->getData('authors')|@count > 4}
 									<span class="collapse-authors" id="show-all-authors"><ion-icon name="add-circle"></ion-icon></span>
 									<span class="collapse-authors hide" id="hide-authors"><ion-icon name="remove-circle"></ion-icon></ion-icon></span>
 								{/if}
@@ -110,7 +110,7 @@
 							</a>
 						{/if}
 						<div class="collapse" id="authorInfoCollapse">
-							{foreach from=$article->getAuthors() item=author key=number}
+							{foreach from=$publication->getData('authors') item=author key=number}
 								<div class="additional-author-block">
 									{if $author->getLocalizedAffiliation() || $author->getLocalizedBiography()}
 										<span class="additional-author-name">{$author->getFullName()|escape}</span>
@@ -157,13 +157,22 @@
 		<div class="main_entry col-md-4" id="mainEntry" >
 
 			{* Article/Issue cover image *}
-			{if $article->getLocalizedCoverImage() || $issue->getLocalizedCoverImage()}
+			{if $publication->getLocalizedData('coverImage') || ($issue && $issue->getLocalizedCoverImage())}
 				<div class="article_cover_wrapper">
-					{if $article->getLocalizedCoverImage()}
-						<img class="img-fluid" src="{$article->getLocalizedCoverImageUrl()|escape}"{if $article->getLocalizedCoverImageAltText()} alt="{$article->getLocalizedCoverImageAltText()|escape}"{/if}>
+					{if $publication->getLocalizedData('coverImage')}
+						{assign var="coverImage" value=$publication->getLocalizedData('coverImage')}
+						<img
+							class="img-fluid"
+							src="{$publication->getLocalizedCoverImageUrl($article->getData('contextId'))|escape}"
+							alt="{$coverImage.altText|escape|default:''}"
+						>
 					{else}
 						<a href="{url page="issue" op="view" path=$issue->getBestIssueId()}">
-							<img class="img-fluid" src="{$issue->getLocalizedCoverImageUrl()|escape}"{if $issue->getLocalizedCoverImageAltText()} alt="{$issue->getLocalizedCoverImageAltText()|escape}"{/if}>
+							<img
+								class="img-fluid"
+								src="{$issue->getLocalizedCoverImageUrl()|escape}"
+								alt="{$issue->getLocalizedCoverImageAltText()|escape|default:''}"
+							>
 						</a>
 					{/if}
 				</div>
@@ -355,10 +364,10 @@
 		<div class="article_abstract_block col-md-8" id="articleAbstractBlock">
 
 			{* Abstract *}
-			{if $article->getLocalizedAbstract()}
+			{if $publication->getLocalizedData('abstract')}
 				<div class="abstract">
 					<h2>{translate key="article.abstract"}</h2>
-					{$article->getLocalizedAbstract()|strip_unsafe_html}
+					{$publication->getLocalizedData('abstract')|strip_unsafe_html}
 				</div>
 			{/if}
 

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -26,6 +26,17 @@
 
 <article class="obj_article_details">
 	<div class="article_header_wrapper">
+		{* Notification that this is an old version *}
+		{if $currentPublication->getId() !== $publication->getId()}
+		<div class="cmp_notification notice" role="alert">
+			{capture assign="latestVersionUrl"}{url page="article" op="view" path=$article->getBestId()}{/capture}
+			{translate key="submission.outdatedVersion"
+				datePublished=$publication->getData('datePublished')|date_format:$dateFormatShort
+				urlRecentVersion=$latestVersionUrl|escape
+			}
+		</div>
+		{/if}
+
 		<div class="article_issue_credentials">
 			<a href="{url page="issue" op="view" path=$issue->getBestIssueId()}">{$issue->getIssueIdentification()|escape}</a>
 		</div>

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -228,9 +228,9 @@
 			{if !empty($keywords[$currentLocale])}
 			<div class="item keywords">
 				{strip}
-				<div class="keywords_label">
+				<h3>
 					{translate key="article.subject"}
-				</div>
+				</h3>
 				<ul class="keywords_value">
 					{foreach from=$keywords item=keywordArray}
 						{foreach from=$keywordArray item=keyword key=k}
@@ -258,9 +258,9 @@
 			{if $citation}
 				<div class="item citation">
 					<div class="sub_item citation_display">
-						<div class="citation_format_label">
+						<h3>
 							{translate key="submission.howToCite"}
-						</div>
+						</h3>
 						<div class="citation_format_value">
 							<div id="citationOutput" role="region" aria-live="polite">
 								{$citation}
@@ -357,7 +357,7 @@
 			{* Abstract *}
 			{if $article->getLocalizedAbstract()}
 				<div class="abstract">
-					<h3 class="abstract_label">{translate key="article.abstract"}</h3>
+					<h2>{translate key="article.abstract"}</h2>
 					{$article->getLocalizedAbstract()|strip_unsafe_html}
 				</div>
 			{/if}

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -15,7 +15,7 @@
  * @uses $primaryGenreIds array List of file genre ids for primary file types
  *}
 
-{assign var=articlePath value=$article->getBestArticleId()}
+{assign var=articlePath value=$article->getBestId()}
 
 {if (!$section.hideAuthor && $article->getHideAuthor() == $smarty.const.AUTHOR_TOC_DEFAULT) || $article->getHideAuthor() == $smarty.const.AUTHOR_TOC_SHOW}
 	{assign var="showAuthor" value=true}

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -72,7 +72,7 @@
 					{/if}
 				{/if}
 				{assign var="hasArticleAccess" value=$hasAccess}
-				{if ($article->getAccessStatus() == $smarty.const.ARTICLE_ACCESS_OPEN)}
+				{if $currentContext->getSetting('publishingMode') == $smarty.const.PUBLISHING_MODE_OPEN || $publication->getData('accessStatus') == $smarty.const.ARTICLE_ACCESS_OPEN}
 					{assign var="hasArticleAccess" value=1}
 				{/if}
 				{include file="frontend/objects/galley_link.tpl" parent=$article hasAccess=$hasArticleAccess purchaseFee=$currentJournal->getSetting('purchaseArticleFee') purchaseCurrency=$currentJournal->getSetting('currency')}

--- a/templates/frontend/objects/galley_link.tpl
+++ b/templates/frontend/objects/galley_link.tpl
@@ -37,7 +37,7 @@
 	{assign var="parentId" value=$parent->getBestIssueId()}
 {else}
 	{assign var="page" value="article"}
-	{assign var="parentId" value=$parent->getBestArticleId()}
+	{assign var="parentId" value=$parent->getBestId()}
 {/if}
 
 {* Get user access flag *}

--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -12,7 +12,7 @@
  * @uses $issueSeries string Vol/No/Year string for the issue
  * @uses $issueGalleys array Galleys for the entire issue
  * @uses $hasAccess bool Can this user access galleys for this context?
- * @uses $publishedArticles array Lists of articles published in this issue
+ * @uses $publishedSubmissions array Lists of articles published in this issue
  *   sorted by section.
  * @uses $primaryGenreIds array List of file genre ids for primary file types
  *}
@@ -85,7 +85,7 @@
 	<h3 class="sr-only">
 		{translate key="issue.toc"}
 	</h3>
-	{foreach name=sections from=$publishedArticles item=section}
+	{foreach name=sections from=$publishedSubmissions item=section}
 		<section class="section">
 			{if $section.articles}
 				{if $section.title}

--- a/templates/frontend/pages/article.tpl
+++ b/templates/frontend/pages/article.tpl
@@ -15,7 +15,7 @@
  * @uses $supplementaryGalleys array List of article galleys that are supplementary
  *}
 
-{include file="frontend/components/header.tpl" pageTitleTranslated=$article->getLocalizedTitle()|escape}
+{include file="frontend/components/header.tpl" pageTitleTranslated=$publication->getLocalizedTitle()|escape}
 
 <main class="page page_article">
 	<div class="container-fluid container-page">

--- a/templates/frontend/pages/indexSite.tpl
+++ b/templates/frontend/pages/indexSite.tpl
@@ -21,7 +21,7 @@
 
 		<div class="index-site-journals">
 			<h2>
-				{translate key="journal.journals"}
+				{translate key="context.contexts"}
 			</h2>
 			{if !count($journals)}
 				{translate key="site.noJournals"}

--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -76,9 +76,10 @@
 
 		{* Search results, finally! *}
 		{if !$results->wasEmpty()}
+
 			<div class="search_results">
 				{iterate from=results item=result}
-					{include file="frontend/objects/article_summary.tpl" headingLevel="2" article=$result.publishedArticle journal=$result.journal showDatePublished=true hideGalleys=true}
+					{include file="frontend/objects/article_summary.tpl" headingLevel="2" article=$result.publishedSubmission journal=$result.journal showDatePublished=true hideGalleys=true}
 				{/iterate}
 			</div>
 		{/if}

--- a/templates/frontend/pages/searchAuthorDetails.tpl
+++ b/templates/frontend/pages/searchAuthorDetails.tpl
@@ -39,7 +39,7 @@
 							<div class="author-details-block author-details-article">
 								<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()}">{$article->getCurrentPublication()->getLocalizedTitle()|strip_unsafe_html}</a>
 							</div>
-							{if (!$issueUnavailable || $article->getAccessStatus() == $smarty.const.ARTICLE_ACCESS_OPEN)}
+							{if (!$issueUnavailable || $publication->getData('accessStatus') == $smarty.const.ARTICLE_ACCESS_OPEN}}
 								<div class="author-details-block author-details-galleys">
 									{foreach from=$article->getGalleys() item=galley name=galleyList}
 										<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()|to_array:$galley->getBestGalleyId()}"

--- a/templates/frontend/pages/searchAuthorDetails.tpl
+++ b/templates/frontend/pages/searchAuthorDetails.tpl
@@ -21,11 +21,11 @@
 			<h3 class="author-details-author text-lg-center">{$lastName|escape}, {$firstName|escape}{if $middleName} {$middleName|escape}{/if}{if $affiliation}, {$affiliation|escape}{/if}{if $country}, {$country|escape}{/if}</h3>
 			<ul class="author-details-articles">
 				{foreach from=$publishedArticles item=article}
-					{assign var=issueId value=$article->getIssueId()}
+					{assign var=issueId value=$article->getCurrentPublication()->getData('issueId')}
 					{assign var=issue value=$issues[$issueId]}
 					{assign var=issueUnavailable value=$issuesUnavailable.$issueId}
 					{assign var=sectionId value=$article->getSectionId()}
-					{assign var=journalId value=$article->getJournalId()}
+					{assign var=journalId value=$article->getData('contextId')}
 					{assign var=journal value=$journals[$journalId]}
 					{assign var=section value=$sections[$sectionId]}
 					{if $issue->getPublished() && $section && $journal}
@@ -37,12 +37,12 @@
 								<span>{$section->getLocalizedTitle()|escape}</span>
 							</div>
 							<div class="author-details-block author-details-article">
-								<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestArticleId()}">{$article->getLocalizedTitle()|strip_unsafe_html}</a>
+								<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()}">{$article->getLocalizedTitle()|strip_unsafe_html}</a>
 							</div>
 							{if (!$issueUnavailable || $article->getAccessStatus() == $smarty.const.ARTICLE_ACCESS_OPEN)}
 								<div class="author-details-block author-details-galleys">
 									{foreach from=$article->getGalleys() item=galley name=galleyList}
-										<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestArticleId()|to_array:$galley->getBestGalleyId()}"
+										<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()|to_array:$galley->getBestGalleyId()}"
 										   class="btn btn-primary">{$galley->getGalleyLabel()|escape}</a>
 									{/foreach}
 								</div>

--- a/templates/frontend/pages/searchAuthorDetails.tpl
+++ b/templates/frontend/pages/searchAuthorDetails.tpl
@@ -20,7 +20,7 @@
 		<div class="page-content" id="authorDetails">
 			<h3 class="author-details-author text-lg-center">{$lastName|escape}, {$firstName|escape}{if $middleName} {$middleName|escape}{/if}{if $affiliation}, {$affiliation|escape}{/if}{if $country}, {$country|escape}{/if}</h3>
 			<ul class="author-details-articles">
-				{foreach from=$publishedArticles item=article}
+				{foreach from=$submissions item=article}
 					{assign var=issueId value=$article->getCurrentPublication()->getData('issueId')}
 					{assign var=issue value=$issues[$issueId]}
 					{assign var=issueUnavailable value=$issuesUnavailable.$issueId}
@@ -37,7 +37,7 @@
 								<span>{$section->getLocalizedTitle()|escape}</span>
 							</div>
 							<div class="author-details-block author-details-article">
-								<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()}">{$article->getLocalizedTitle()|strip_unsafe_html}</a>
+								<a href="{url journal=$journal->getPath() page="article" op="view" path=$article->getBestId()}">{$article->getCurrentPublication()->getLocalizedTitle()|strip_unsafe_html}</a>
 							</div>
 							{if (!$issueUnavailable || $article->getAccessStatus() == $smarty.const.ARTICLE_ACCESS_OPEN)}
 								<div class="author-details-block author-details-galleys">

--- a/templates/plugins/generic/htmlArticleGalley/templates/display.tpl
+++ b/templates/plugins/generic/htmlArticleGalley/templates/display.tpl
@@ -11,7 +11,7 @@
 
 <!DOCTYPE html>
 <html lang="{$currentLocale|replace:"_":"-"}" xml:lang="{$currentLocale|replace:"_":"-"}">
-{capture assign="pageTitleTranslated"}{translate key="article.pageTitle" title=$article->getLocalizedTitle()|escape}{/capture}
+{capture assign="pageTitleTranslated"}{translate key="article.pageTitle" title=$galleyPublication->getLocalizedTitle()|escape}{/capture}
 {include file="frontend/components/headerHead.tpl"}
 <body class="pkp_page_{$requestedPage|escape} pkp_op_{$requestedOp|escape}">
 
@@ -23,10 +23,19 @@
 			{translate key="article.return"}
 		</span>
 	</a>
-
+	{if !$isLatestPublication}
+	<div class="cmp_notification notice" role="alert">
+		{translate key="submission.outdatedVersion"
+			datePublished=$galleyPublication->getData('datePublished')|date_format:$dateFormatLong
+			urlRecentVersion=$parentUrl
+		}
+	</div>
+	{else}
 	<a href="{url page="article" op="view" path=$article->getBestId()}" class="title">
-		{$article->getLocalizedTitle()|escape}
+		{$galleyPublication->getLocalizedTitle()|escape}
 	</a>
+	{/if}
+
 </header>
 
 <div id="htmlContainer" class="galley_view" style="overflow:visible;-webkit-overflow-scrolling:touch">

--- a/templates/plugins/generic/htmlArticleGalley/templates/display.tpl
+++ b/templates/plugins/generic/htmlArticleGalley/templates/display.tpl
@@ -18,19 +18,19 @@
 {* Header wrapper *}
 <header class="header_view">
 
-	<a href="{url page="article" op="view" path=$article->getBestArticleId()}" class="return">
+	<a href="{url page="article" op="view" path=$article->getBestId()}" class="return">
 		<span class="pkp_screen_reader">
 			{translate key="article.return"}
 		</span>
 	</a>
 
-	<a href="{url page="article" op="view" path=$article->getBestArticleId()}" class="title">
+	<a href="{url page="article" op="view" path=$article->getBestId()}" class="title">
 		{$article->getLocalizedTitle()|escape}
 	</a>
 </header>
 
 <div id="htmlContainer" class="galley_view" style="overflow:visible;-webkit-overflow-scrolling:touch">
-	<iframe id="htmlGalleyFrame" name="htmlFrame" src="{url page="article" op="download" path=$article->getBestArticleId()|to_array:$galley->getBestGalleyId() inline=true}" allowfullscreen webkitallowfullscreen></iframe>
+	<iframe id="htmlGalleyFrame" name="htmlFrame" src="{url page="article" op="download" path=$article->getBestId()|to_array:$galley->getBestGalleyId() inline=true}" allowfullscreen webkitallowfullscreen></iframe>
 </div>
 {call_hook name="Templates::Common::Footer::PageFooter"}
 

--- a/templates/plugins/generic/pdfJsViewer/templates/display.tpl
+++ b/templates/plugins/generic/pdfJsViewer/templates/display.tpl
@@ -24,9 +24,19 @@
 						{translate key="article.return"}
 					{/if}
 				</span>
-				{$title|escape}
+				{if $isLatestPublication}
+					{$title|escape}
+				{/if}
 			</a>
 		</div>
+		{if !$isLatestPublication}
+		<div class="cmp_notification notice" role="alert">
+			{translate key="submission.outdatedVersion"
+				datePublished=$galleyPublication->getData('datePublished')|date_format:$dateFormatLong
+				urlRecentVersion=$parentUrl
+			}
+		</div>
+		{/if}
 		<div class="pdf-download-button">
 			<a href="{$pdfUrl}" class="btn btn-primary" download>
 				<span class="label">

--- a/templates/plugins/generic/recommendByAuthor/templates/articleFooter.tpl
+++ b/templates/plugins/generic/recommendByAuthor/templates/articleFooter.tpl
@@ -25,7 +25,7 @@
 						{foreach from=$article->getAuthors() item=author}
 							{$author->getFullName()|escape},
 						{/foreach}
-						<a href="{url journal=$journal->getPath() page="article" op="view" path=$publishedArticle->getBestArticleId()}">
+						<a href="{url journal=$journal->getPath() page="article" op="view" path=$publishedArticle->getBestId()}">
 							{$article->getLocalizedTitle()|strip_unsafe_html}
 						</a>,
 						<a href="{url journal=$journal->getPath() page="issue" op="view" path=$issue->getBestIssueId()}">

--- a/templates/plugins/generic/recommendByAuthor/templates/articleFooter.tpl
+++ b/templates/plugins/generic/recommendByAuthor/templates/articleFooter.tpl
@@ -26,7 +26,7 @@
 							{$author->getFullName()|escape},
 						{/foreach}
 						<a href="{url journal=$journal->getPath() page="article" op="view" path=$publishedArticle->getBestId()}">
-							{$article->getLocalizedTitle()|strip_unsafe_html}
+							{$article->getCurrentPublication()->getLocalizedTitle()|strip_unsafe_html}
 						</a>,
 						<a href="{url journal=$journal->getPath() page="issue" op="view" path=$issue->getBestIssueId()}">
 							{$journal->getLocalizedName()|escape}: {$issue->getIssueIdentification()|escape}


### PR DESCRIPTION
This PR adds support for versioning in 3.2 and adjusts for new split between publications and submissions. Some screenshots of what's been added, based on Sophy's work in #56.

## Notice when viewing old version of article.
![Selection_208](https://user-images.githubusercontent.com/2306629/74752783-1f645680-5267-11ea-8436-58076d60ccdd.png)

## Navigate between versions from article landing page.
![Selection_209](https://user-images.githubusercontent.com/2306629/74752784-20958380-5267-11ea-924d-8479cc36dba7.png)

## Notice when viewing old PDF galley
![Selection_210](https://user-images.githubusercontent.com/2306629/74752786-20958380-5267-11ea-87ec-b604abaa05d4.png)

## Notice when viewing old HTML galley
![Selection_211](https://user-images.githubusercontent.com/2306629/74752790-212e1a00-5267-11ea-9410-23d7dd147798.png)

If there's anything here that needs further design work, we can tidy that up and put out a new release after 3.2 goes out. But this should at least get us compatible with 3.2 in time for release.
