### PR TITLE
Includes Hook for additional filters on the search page

### DIFF
--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -66,6 +66,7 @@
 					<div class="filter-authors">
 						<input type="text" class="form-control" for="authors" name="authors" value="{$authors|escape}" placeholder="{translate key="search.author"}">
 					</div>
+					{call_hook name="Templates::Search::SearchResults::AdditionalFilters"}
 				</fieldset>
 
 


### PR DESCRIPTION
Hi! :smiley: 
This PR adds a [Hook](https://github.com/pkp/ojs/blob/cd1b7b512df38e8f7c204432702e137ab06f0b64/templates/frontend/pages/search.tpl#L87) that is present in the default OJS theme and is useful for plugins that add customized search filters.